### PR TITLE
New feature - Allow pgmetadata module to serve a DCAT catalog in RDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 ## PgMetadata Module
 
-This module is designed for Lizmap Web Client, and allows to display PostgreSQL layers metadata stored in the layer database.
+This module is designed for Lizmap Web Client, and allows displaying PostgreSQL layers metadata stored in the 
+layer database.
 
-The metadata must be created in the PostgreSQL database as designed in the [PgMetadata QGIS plugin](https://github.com/3liz/qgis-pgmetadata-plugin).
+The metadata must be created in the PostgreSQL database as designed in the 
+[PgMetadata QGIS plugin](https://github.com/3liz/qgis-pgmetadata-plugin).
 
 ![Metadata information panel](metadata_information_panel.jpeg)
 
@@ -10,9 +12,11 @@ The metadata must be created in the PostgreSQL database as designed in the [PgMe
 
 Once Lizmap Web Client application is installed and working, you can install the pgmetadata module:
 
-* Get the last ZIP archive in the [release page](https://github.com/3liz/lizmap-pgmetadata-module/releases) of the github repository.
+* Get the last ZIP archive in the [release page](https://github.com/3liz/lizmap-pgmetadata-module/releases) of
+  the github repository.
 * Extract the archive and copy the `pgmetadata` directory in Lizmap Web Client folder `lizmap/lizmap-modules/`
-* Edit the config file `lizmap/var/config/localconfig.ini.php` and add (or adapt) the section `[modules]` by adding the `pgmetadata.access=2`
+* Edit the config file `lizmap/var/config/localconfig.ini.php` and add (or adapt) the section `[modules]` by 
+  adding the `pgmetadata.access=2`
 
 ```ini
 [modules]
@@ -29,7 +33,10 @@ lizmap/install/set_rights.sh
 
 ### Publish your metadata as a DCAT catalog
 
-If you need to publish your metadata catalog as a RDF catalog, for example to be harvested by a third-party metadata platform such as Ckan, you need to declare in the file `lizmap/var/config/profiles.ini.php` a new section [jdb:pgmetadata] with the needed credentials to your PostgreSQL database hosting the metadata. For example:
+If you need to publish your metadata catalog as an RDF catalog, for example to be harvested by a third-party 
+metadata platform such as Ckan, you need to declare in the file `lizmap/var/config/profiles.ini.php` a new 
+section `[jdb:pgmetadata]` with the needed credentials to your PostgreSQL database hosting the metadata. For 
+example:
 
 ```ini
 [jdb:pgmetadata]
@@ -38,14 +45,14 @@ database=pgmetadata
 host=localhost
 port=5432
 user=your_user
-password=your_passord
+password=your_password
 persistent=off
 ;search_path=""
 ```
 
 Then, you would be able to access the
 
-* full RDF catalog with an URL like: http://[YOUR_HOST]/index.php/pgmetadata/dcat/
+* full RDF catalog with a URL like: http://[YOUR_HOST]/index.php/pgmetadata/dcat/
 * one dataset record with: http://[YOUR_HOST]/index.php/pgmetadata/dcat/?id=76853e57-387e-4b8d-9ee8-f176e11cd9ce
 
 The XML created would be like

--- a/README.md
+++ b/README.md
@@ -27,6 +27,79 @@ lizmap/install/clean_vartmp.sh
 lizmap/install/set_rights.sh
 ```
 
+### Publish your metadata as a DCAT catalog
+
+If you need to publish your metadata catalog as a RDF catalog, for example to be harvested by a third-party metadata platform such as Ckan, you need to declare in the file `lizmap/var/config/profiles.ini.php` a new section [jdb:pgmetadata] with the needed credentials to your PostgreSQL database hosting the metadata. For example:
+
+```ini
+[jdb:pgmetadata]
+driver=pgsql
+database=pgmetadata
+host=localhost
+port=5432
+user=your_user
+password=your_passord
+persistent=off
+;search_path=""
+```
+
+Then, you would be able to access the
+
+* full RDF catalog with an URL like: http://[YOUR_HOST]/index.php/pgmetadata/dcat/
+* one dataset record with: http://[YOUR_HOST]/index.php/pgmetadata/dcat/?id=76853e57-387e-4b8d-9ee8-f176e11cd9ce
+
+The XML created would be like
+
+```xml
+<dcat:dataset>
+  <dcat:Dataset rdf:about="http://lizmap.localhost/index.php/pgmetadata/dcat/?id=76853e57-387e-4b8d-9ee8-f176e11cd9ce">
+    <dct:identifier>76853e57-387e-4b8d-9ee8-f176e11cd9ce</dct:identifier>
+    <dct:title>Test title</dct:title>
+    <dct:description>Test abstract.</dct:description>
+    <dct:language>en</dct:language>
+    <dct:license>Licence Ouverte Version 2.1</dct:license>
+    <dct:rights>Open</dct:rights>
+    <dct:accrualPeriodicity>Yearly</dct:accrualPeriodicity>
+    <dct:spatial>{"type":"Polygon","coordinates":[[[3.854,43.5786],[3.854,43.622],[3.897,43.622],[3.897,43.5786],[3.854,43.5786]]]}</dct:spatial>
+    <dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-31T09:16:16.980258</dct:created>
+    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-31T09:16:16.980258</dct:issued>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-12-31T09:16:16.980258</dct:modified>
+    <dcat:contactPoint>
+      <vcard:Organization>
+        <vcard:fn>Jane Doe - Acme (GIS)</vcard:fn>
+        <vcard:hasEmail rdf:resource="jane.doe@acme.gis">jane.doe@acme.gis</vcard:hasEmail>
+      </vcard:Organization>
+    </dcat:contactPoint>
+    <dct:creator>
+      <foaf:Organization>
+        <foaf:name>Jane Doe - Acme (GIS)</foaf:name>
+        <foaf:mbox>jane.doe@acme.gis</foaf:mbox>
+      </foaf:Organization>
+    </dct:creator>
+    <dct:publisher>
+      <foaf:Organization>
+        <foaf:name>Bob Robert - Corp (Spatial div)</foaf:name>
+        <foaf:mbox>bob.bob@corp.spa</foaf:mbox>
+      </foaf:Organization>
+    </dct:publisher>
+    <dcat:distribution>
+      <dcat:Distribution>
+        <dct:title>test link</dct:title>
+        <dct:description>Link description</dct:description>
+        <dcat:downloadURL>https://metadata.is.good</dcat:downloadURL>
+        <dcat:mediaType>application/pdf</dcat:mediaType>
+        <dct:format>a file</dct:format>
+        <dct:bytesize>590</dct:bytesize>
+      </dcat:Distribution>
+    </dcat:distribution>
+    <dcat:keyword>tag_one</dcat:keyword>
+    <dcat:keyword>tag_two</dcat:keyword>
+    <dcat:theme>test theme</dcat:theme>
+    <dcat:theme>New test theme</dcat:theme>
+  </dcat:Dataset>
+</dcat:dataset>
+```
+
 ## Contribution guide
 
 For PHP, the project is using PHP-CS-Fixer.

--- a/pgmetadata/classes/search.class.php
+++ b/pgmetadata/classes/search.class.php
@@ -10,10 +10,10 @@
 class search
 {
     protected $sql = array(
-        'check_dataset' => "SELECT tablename FROM pg_tables WHERE schemaname = 'pgmetadata' AND tablename = 'dataset'",
-        'get_html' => 'SELECT pgmetadata.get_dataset_item_html_content($1, $2, $3) AS html',
-        'get_html_default' => 'SELECT pgmetadata.get_dataset_item_html_content($1, $2) AS html',
-        'get_version' => "SELECT column_name FROM information_schema.columns WHERE table_schema = 'pgmetadata' AND table_name = 'glossary' AND column_name LIKE 'label_%';",
+        'check_pgmetadata_installed' => "SELECT tablename FROM pg_tables WHERE schemaname = 'pgmetadata' AND tablename = 'dataset'",
+        'get_translated_locale_columns' => "SELECT column_name FROM information_schema.columns WHERE table_schema = 'pgmetadata' AND table_name = 'glossary' AND column_name LIKE 'label_%';",
+        'get_dataset_html_content' => 'SELECT pgmetadata.get_dataset_item_html_content($1, $2, $3) AS html',
+        'get_dataset_html_content_default_locale' => 'SELECT pgmetadata.get_dataset_item_html_content($1, $2) AS html',
     );
 
     protected function getSql($option)
@@ -25,9 +25,15 @@ class search
         return null;
     }
 
-    public function query($sql, $filterParams, $profile = 'pgmetadata')
+    public function query($sql, $filterParams, $profile)
     {
-        $cnx = jDb::getConnection($profile);
+        if ($profile) {
+            $cnx = jDb::getConnection($profile);
+        } else {
+            // Default connection
+            $cnx = jDb::getConnection();
+        }
+
         $resultset = $cnx->prepare($sql);
         if (empty($filterParams)) {
             $resultset->execute();
@@ -45,7 +51,7 @@ class search
      * @param mixed $filterParams
      * @param mixed $option
      */
-    public function getData($profile, $filterParams, $option)
+    public function getData($option='check_pgmetadata_installed', $filterParams=array(), $profile=null)
     {
         // Run query
         $sql = $this->getSql($option);

--- a/pgmetadata/classes/search.class.php
+++ b/pgmetadata/classes/search.class.php
@@ -10,10 +10,18 @@
 class search
 {
     protected $sql = array(
+        // generic
         'check_pgmetadata_installed' => "SELECT tablename FROM pg_tables WHERE schemaname = 'pgmetadata' AND tablename = 'dataset'",
+
+        // html export
         'get_translated_locale_columns' => "SELECT column_name FROM information_schema.columns WHERE table_schema = 'pgmetadata' AND table_name = 'glossary' AND column_name LIKE 'label_%';",
         'get_dataset_html_content' => 'SELECT pgmetadata.get_dataset_item_html_content($1, $2, $3) AS html',
         'get_dataset_html_content_default_locale' => 'SELECT pgmetadata.get_dataset_item_html_content($1, $2) AS html',
+
+        // dcat export
+        'check_dcat_support' => "SELECT viewname FROM pg_views WHERE schemaname = 'pgmetadata' AND viewname = 'v_dataset_as_dcat'",
+        'get_rdf_dcat_catalog' => 'SELECT * FROM pgmetadata.get_datasets_as_dcat_xml($1) WHERE True',
+        'get_rdf_dcat_catalog_by_id' => 'SELECT * FROM pgmetadata.get_datasets_as_dcat_xml($1) WHERE uid = $2::uuid',
     );
 
     protected function getSql($option)
@@ -51,20 +59,36 @@ class search
      * @param mixed $filterParams
      * @param mixed $option
      */
-    public function getData($option='check_pgmetadata_installed', $filterParams=array(), $profile=null)
+    public function getData($option = 'check_pgmetadata_installed', $filterParams = array(), $profile = null)
     {
         // Run query
         $sql = $this->getSql($option);
         if (!$sql) {
-            return null;
+            return array(
+                'status' => 'error',
+                'message' => 'No SQL found for '.$option,
+            );
         }
 
         try {
             $result = $this->query($sql, $filterParams, $profile);
         } catch (Exception $e) {
-            return array('status' => 'error', 'message' => 'Error at the query concerning '.$option);
+            return array(
+                'status' => 'error',
+                'message' => 'Error at the query concerning '.$option,
+            );
         }
 
-        return $result->fetchAll();
+        if (!$result) {
+            return array(
+                'status' => 'error',
+                'message' => 'Error at the query concerning '.$option,
+            );
+        }
+
+        return array(
+            'status' => 'success',
+            'data' => $result->fetchAll(),
+        );
     }
 }

--- a/pgmetadata/controllers/dcat.classic.php
+++ b/pgmetadata/controllers/dcat.classic.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * @author    Michaël DOUCHIN
+ * @copyright 2020 3liz
+ *
+ * @see      https://3liz.com
+ *
+ * @license    All rights reserved
+ */
+class dcatCtrl extends jController
+{
+    /**
+     * Check if a given string is a valid UUID.
+     *
+     * @param string $uuid The string to check
+     *
+     * @return bool
+     */
+    private function isValidUuid($uuid)
+    {
+        if (!is_string($uuid) || (preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/', $uuid) !== 1)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function index()
+    {
+        $rep = $this->getResponse('xml');
+
+        $project = $this->param('project');
+        $repository = $this->param('repository');
+        $option = 'get_dcat_rdf_catalog';
+        $search = jClasses::getService('pgmetadata~search');
+
+        // Check pgmetadata needed view exists in profile 'pgmetadata'
+        // Else try with defaut
+        // Return empty content on failure
+        $profiles = array('pgmetadata', null);
+        $ok = false;
+        $p = null;
+        foreach ($profiles as $profile) {
+            $result = $search->getData('check_dcat_support', array(), $profile);
+            if ($result['status'] == 'success' && !empty($result['status'])) {
+                $ok = true;
+                $p = $profile;
+
+                break;
+            }
+        }
+
+        // Generate empty content from template
+        $tpl = new jTpl();
+        $assign = array();
+        $locale = jLocale::getCurrentLang();
+        $assign['locale'] = $locale;
+        $assign['content'] = '';
+        $tpl->assign($assign);
+        $empty_content = $tpl->fetch('pgmetadata~dcat_catalog');
+
+        // Return empty content if needed
+        if (!$ok) {
+            $rep->content = $empty_content;
+
+            return $rep;
+        }
+
+        $profile = $p;
+        $filterParams = array();
+
+        // Get current locale: en, fr, etc.
+        $locale = jLocale::getCurrentLang();
+        if (strlen($locale) != 2) {
+            $locale = 'en';
+        }
+        $filterParams[] = $locale;
+
+        // If id is passed as parameter, filter by this UUID
+        $id = trim($this->param('id', ''));
+        $option = 'get_rdf_dcat_catalog';
+        if (!empty($id)) {
+            if ($this->isValidUuid($id)) {
+                $option = 'get_rdf_dcat_catalog_by_id';
+                $filterParams[] = $id;
+            } else {
+                $rep->content = $empty_content;
+
+                return $rep;
+            }
+        }
+        $result = $search->getData($option, $filterParams, $profile);
+
+        // Check if getData doesn't return an error
+        if ($result['status'] == 'error') {
+            $rep->content = $empty_content;
+
+            return $rep;
+        }
+        $datasets = $result['data'];
+        $content = '';
+
+        foreach ($datasets as $dataset) {
+            $dataset_url = $url = jUrl::getFull(
+                'pgmetadata~dcat:index',
+                array('id' => $dataset->uid)
+            );
+            $content .= str_replace(
+                '<dcat:Dataset>',
+                '<dcat:Dataset rdf:about="'.$dataset_url.'">',
+                $dataset->dataset
+            );
+        }
+
+        $assign['content'] = $content;
+        $tpl->assign($assign);
+        $rep->content = $tpl->fetch('pgmetadata~dcat_catalog');
+
+        return $rep;
+    }
+}

--- a/pgmetadata/controllers/service.classic.php
+++ b/pgmetadata/controllers/service.classic.php
@@ -85,35 +85,40 @@ class serviceCtrl extends jController
         $search = jClasses::getService('pgmetadata~search');
 
         $result = $search->getData('check_pgmetadata_installed', array(), $profile);
-        if (isset($result['status'])) {
+        if ($result['status'] == 'error') {
             $rep->data = $result;
 
             return $rep;
         }
 
-        if (empty($result)) {
-            $rep->data = array('status' => 'error', 'message' => 'Table pgmetadata.dataset does not exist in the layer database');
+        if (empty($result['data'])) {
+            $rep->data = array(
+                'status' => 'error',
+                'message' => 'Table pgmetadata.dataset does not exist in the layer database',
+            );
 
             return $rep;
         }
 
-        // Get Locale for the html langage
-        // Jelix sanitizes the locale. No need to validate the string given by jLocale
+        // Get currrent locale: en, fr, etc.
         $locale = jLocale::getCurrentLang();
+        if (strlen($locale) != 2) {
+            $locale = 'en';
+        }
 
         // Check if the database glossary table contains locale label_XX columns
         $result = $search->getData('get_translated_locale_columns', array(), $profile);
 
         // Check if getData doesn't return an error
-        // If $result['status'] is define there is an error
-        if (isset($result['status'])) {
+        if ($result['status'] == 'error') {
             $rep->data = $result;
+
             return $rep;
         }
 
         // Check if no locales label_xx columns were returned
         // We then need to use the old get html function
-        if (count($result) == 0) {
+        if (empty($result['data'])) {
             $option = 'get_dataset_html_content_default_locale';
         } else {
             $option = 'get_dataset_html_content';
@@ -124,23 +129,30 @@ class serviceCtrl extends jController
         $result = $search->getData($option, $filterParams, $profile);
 
         // Check if getData doesn't return an error
-        // If $result['status'] is define there is an error
-        if (isset($result['status'])) {
+        if ($result['status'] == 'error') {
             $rep->data = $result;
 
             return $rep;
         }
 
         // Check content and return
-        if (count($result) == 0) {
-            $rep->data = array('status' => 'error', 'message' => 'No line returned by the query');
+        if (empty($result['data'])) {
+            $rep->data = array(
+                'status' => 'error',
+                'message' => 'No line returned by the query',
+            );
 
             return $rep;
         }
-        $feature = $result[0];
+
+        // Get content
+        $feature = $result['data'][0];
 
         // Return  HTML
-        $rep->data = array('status' => 'success', 'html' => $feature->html);
+        $rep->data = array(
+            'status' => 'success',
+            'html' => $feature->html,
+        );
 
         return $rep;
     }

--- a/pgmetadata/templates/dcat_catalog.tpl
+++ b/pgmetadata/templates/dcat_catalog.tpl
@@ -1,0 +1,19 @@
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:dct="http://purl.org/dc/terms/"
+    xmlns:dcat="http://www.w3.org/ns/dcat#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:foaf="http://xmlns.com/foaf/0.1/"
+    xmlns:adms="http://www.w3.org/ns/adms#"
+    xmlns:vcard="http://www.w3.org/2006/vcard/ns#"
+    xmlns:schema="http://schema.org/"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+<dcat:Catalog rdf:about="https://lizmap.com">
+    <dct:description>PgMetadata DCAT RDF catalog</dct:description>
+    <dct:language>{$locale}</dct:language>
+    <dct:title>PgMetadata</dct:title>
+
+    {$content}
+
+</dcat:Catalog>
+</rdf:RDF>


### PR DESCRIPTION
This would allow to let third-party application, such as CKAN, harvest the metadata stored in the PgMetadata PostgreSQL datastore.
